### PR TITLE
feat: Remove instance lock mechanism

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -757,10 +757,6 @@ async def main() -> None:
     # --- Initialization ---
     await db.initialize_db()
 
-    # --- Attempt to acquire lock ---
-    if not await db.acquire_lock():
-        logger.info("Another instance is already running. Shutting down this instance.")
-        return
 
     try:
         loaded_settings = await db.load_all_settings()
@@ -817,9 +813,6 @@ async def main() -> None:
     except (KeyboardInterrupt, SystemExit):
         logger.info("Received stop signal")
     finally:
-        # --- Release the lock on shutdown ---
-        await db.release_lock()
-
         # Gracefully stop the application
         if 'application' in locals() and application.updater:
             await application.updater.stop()


### PR DESCRIPTION
Removes the database-backed instance lock feature.

This feature was causing deployment issues on Choreo, where the lock from a previous instance would prevent a new instance from starting.

The changes include:
- Removing the `instance_lock` table from the database schema.
- Deleting the `acquire_lock` and `release_lock` functions from `db.py`.
- Removing the lock acquisition and release logic from `bot.py`.