### PR TITLE
This commit resolves an issue where the bot would experience timeout …

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,8 @@ from datetime import timedelta
 from spotipy.oauth2 import SpotifyClientCredentials
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ParseMode, ChatMemberStatus
-from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters, CallbackQueryHandler, ConversationHandler
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters, CallbackQueryHandler, ConversationHandler, Defaults
+from telegram.error import TimedOut
 from aiohttp import web
 from mutagen.mp4 import MP4, MP4Cover
 from mutagen import MutagenError
@@ -584,25 +585,20 @@ async def download_and_send_song(update: Update, application: Application, info:
 
         try:
             with open(downloaded_file, 'rb') as audio_file:
-                sent_message = await asyncio.wait_for(
-                    application.bot.send_audio(
-                        chat_id=chat_id,
-                        audio=audio_file,
-                        caption=caption,
-                        title=title,
-                        performer=artist,
-                        duration=duration,
-                        parse_mode=ParseMode.MARKDOWN,
-                        thumbnail=thumbnail_bytes,
-                        read_timeout=60,
-                        write_timeout=60,
-                        connect_timeout=60
-                    ),
-                    timeout=120
+                sent_message = await application.bot.send_audio(
+                    chat_id=chat_id,
+                    audio=audio_file,
+                    caption=caption,
+                    title=title,
+                    performer=artist,
+                    duration=duration,
+                    parse_mode=ParseMode.MARKDOWN,
+                    thumbnail=thumbnail_bytes,
+                    timeout=180  # Use a single timeout parameter
                 )
-        except asyncio.TimeoutError:
-            logger.error("Upload timed out")
-            await message.edit_text("❌ Upload timed out. The file might be too large or connection is slow.")
+        except TimedOut:
+            logger.error("Upload timed out after 180 seconds")
+            await message.edit_text("❌ Upload timed out. The file might be too large or the connection is slow.")
             return
 
         if delay > 0:
@@ -660,13 +656,16 @@ async def main() -> None:
         logger.info(f"Loaded settings: {loaded_settings}")
 
         # --- Application Setup ---
+        defaults = Defaults(
+            timeout=60,
+            connect_timeout=60,
+            read_timeout=60,
+            write_timeout=60
+        )
         application = (
             Application.builder()
             .token(config.BOT_TOKEN)
-            .read_timeout(120)
-            .write_timeout(120)
-            .connect_timeout(60)
-            .pool_timeout(120)
+            .defaults(defaults)
             .post_init(start_health_check_server)
             .post_init(start_queue_worker)
             .post_shutdown(shutdown_health_check_server)


### PR DESCRIPTION
…errors when uploading larger audio files to Telegram.

The `python-telegram-bot` library's timeout handling was updated to use the modern API.

Key changes:
- Replaced deprecated `read_timeout`, `write_timeout`, and `connect_timeout` in the `Application.builder` with a `Defaults` object for global timeout configuration.
- Removed the `asyncio.wait_for` wrapper around the `send_audio` call.
- Implemented a direct `timeout=180` parameter in the `send_audio` call to allow more time for uploads.
- Updated the exception handling to catch `telegram.error.TimedOut` instead of `asyncio.TimeoutError`.